### PR TITLE
[no-jira] Capybara not needed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,13 @@ group :development do
   # gem "spring"
 end
 
+group :test do
+  # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
+  # gem "capybara"
+  # gem "selenium-webdriver"
+  # gem "webdrivers"
+end
+
 gem "awesome_print"
 gem "brakeman"
 gem "bundle-audit"

--- a/Gemfile
+++ b/Gemfile
@@ -68,13 +68,6 @@ group :development do
   # gem "spring"
 end
 
-group :test do
-  # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
-  gem "capybara"
-  gem "selenium-webdriver"
-  gem "webdrivers"
-end
-
 gem "awesome_print"
 gem "brakeman"
 gem "bundle-audit"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,8 +72,6 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.1)
-      public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     awesome_print (1.9.2)
     bindex (0.8.1)
@@ -86,16 +84,6 @@ GEM
     bundler-audit (0.9.0.1)
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
-    capybara (3.37.1)
-      addressable
-      matrix
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (>= 1.5, < 3.0)
-      xpath (~> 3.2)
-    childprocess (4.1.0)
     concurrent-ruby (1.2.2)
     connection_pool (2.3.0)
     crass (1.0.6)
@@ -146,7 +134,6 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.2)
-    matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.2)
@@ -171,7 +158,6 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.1)
       ast (~> 2.4.1)
-    public_suffix (5.0.0)
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.7.1)
@@ -240,7 +226,6 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.11.0)
-    rubyzip (2.0.0)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -249,10 +234,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.0.0.rc3)
-      childprocess (>= 0.5, < 5.0)
-      rexml (~> 3.2)
-      rubyzip (>= 1.2.2)
     sidekiq (6.5.7)
       connection_pool (>= 2.2.5)
       rack (~> 2.0)
@@ -286,15 +267,9 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (4.3.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (>= 3.0, < 4.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xpath (3.2.0)
-      nokogiri (~> 1.8)
     zeitwerk (2.6.8)
 
 PLATFORMS
@@ -305,7 +280,6 @@ DEPENDENCIES
   bootsnap
   brakeman
   bundle-audit
-  capybara
   ddtrace (~> 1.4)
   debug
   dogstatsd-ruby (~> 5.3)
@@ -319,7 +293,6 @@ DEPENDENCIES
   rake
   redis-actionpack
   sassc-rails
-  selenium-webdriver
   sidekiq
   sidekiq-pro!
   sprockets-rails
@@ -330,7 +303,6 @@ DEPENDENCIES
   tzinfo-data
   uri (~> 0.10.3)
   web-console
-  webdrivers
 
 RUBY VERSION
    ruby 3.0.6p216

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.13.0)
       msgpack (~> 1.2)
-    brakeman (6.0.0)
+    brakeman (6.0.1)
     builder (3.2.4)
     bundle-audit (0.1.0)
       bundler-audit


### PR DESCRIPTION
`gem "webdrivers"` will no longer work with the latest chrome / chromedriver, but rather than update 'em, just get rid of 'em, they're not needed here.