### PR TITLE
Adopt thruster (replaces nginx sidecar for static assets)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,13 +49,12 @@ VOLUME /home/webapp/app/nginx-conf
 # Run container process as non-root user
 USER webapp
 
-# Thruster fronts Puma (HTTP caching/compression + static file serving).
-# HTTP_PORT=3000 keeps the container listening on the port Puma used to bind
-# (the port the existing ECS task definition / nginx sidecar expects), instead
-# of Thruster's default 80. Puma moves to the internal-only TARGET_PORT —
-# Thruster sets PORT for the child process, and config/puma.rb honors it.
-ENV HTTP_PORT=3000 \
-    TARGET_PORT=3001
+# Thruster fronts Puma (HTTP caching/compression + static file serving) on its
+# default port 80, proxying to Puma on 3000 — the fl-pos-admin fleet pattern.
+# While the nginx sidecar still exists it proxies straight to Puma:3000
+# (Thruster sits idle); after the cru-terraform nginx removal the ALB points
+# at this container on 80.
+EXPOSE 80
 
 # Start server via Thruster by default, this can be overwritten at runtime
 CMD ["./bin/thrust", "./bin/rails", "server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,5 +56,10 @@ USER webapp
 # at this container on 80.
 EXPOSE 80
 
+# Thruster request logs (default on) would interleave a Go slog JSON stream into the
+# same stdout as the app's structured Ougai/lograge logs (Datadog pipeline is keyed on
+# that format) and re-log the silenced health checks; request logging is lograge's job.
+ENV LOG_REQUESTS="false"
+
 # Start server via Thruster by default, this can be overwritten at runtime
 CMD ["./bin/thrust", "./bin/rails", "server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,5 +49,13 @@ VOLUME /home/webapp/app/nginx-conf
 # Run container process as non-root user
 USER webapp
 
-# Command to start rails
-CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]
+# Thruster fronts Puma (HTTP caching/compression + static file serving).
+# HTTP_PORT=3000 keeps the container listening on the port Puma used to bind
+# (the port the existing ECS task definition / nginx sidecar expects), instead
+# of Thruster's default 80. Puma moves to the internal-only TARGET_PORT —
+# Thruster sets PORT for the child process, and config/puma.rb honors it.
+ENV HTTP_PORT=3000 \
+    TARGET_PORT=3001
+
+# Start server via Thruster by default, this can be overwritten at runtime
+CMD ["./bin/thrust", "./bin/rails", "server"]

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem "bootsnap", require: false
 # gem "kamal", require: false
 
 # Add HTTP asset caching/compression and X-Sendfile acceleration to Puma [https://github.com/basecamp/thruster/]
-# gem "thruster", require: false
+gem "thruster", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,6 +309,8 @@ GEM
       railties (>= 6.0.0)
     stringio (3.2.0)
     thor (1.5.0)
+    thruster (0.1.23)
+    thruster (0.1.23-x86_64-linux)
     timeout (0.6.1)
     tsort (0.2.0)
     turbo-rails (2.0.20)
@@ -360,6 +362,7 @@ DEPENDENCIES
   sqlite3 (>= 2.1)
   standard
   stimulus-rails
+  thruster
   turbo-rails
   tzinfo-data
   web-console
@@ -477,6 +480,8 @@ CHECKSUMS
   stimulus-rails (1.2.1) sha256=831bbcc0c12ea9c751e0a96b85d9908a0e4b42031964724d5b507166e06f0e8a
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
+  thruster (0.1.23) sha256=ad3081e8ff3b5cb413768292c367f1e015c423bb6b35919b9b9f533af50d639f
+  thruster (0.1.23-x86_64-linux) sha256=9cd7265bf54e954575c8442e42d050ed8eb55df4f9d7da8fd6f94fcc0339baa5
   timeout (0.6.1) sha256=78f57368a7e7bbadec56971f78a3f5ecbcfb59b7fcbb0a3ed6ddc08a5094accb
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
   turbo-rails (2.0.20) sha256=cbcbb4dd3ce59f6471c9f911b1655b2c721998cc8303959d982da347f374ea95

--- a/bin/thrust
+++ b/bin/thrust
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+require "rubygems"
+require "bundler/setup"
+
+load Gem.bin_path("thruster", "thrust")

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -15,8 +15,8 @@ Rails.application.configure do
   # Turn on fragment caching in view templates.
   config.action_controller.perform_caching = true
 
-  # Disable serving static files from `public/`, relying on NGINX/Apache to do so instead.
-  config.public_file_server.enabled = false
+  # Cache assets for far-future expiry since they are all digest stamped.
+  config.public_file_server.headers = {"cache-control" => "public, max-age=#{1.year.to_i}"}
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"


### PR DESCRIPTION
Stacked on #141 (`rails-8.0-propshaft`), which is stacked on #140 (`rails-8.0-upgrade`). Adopts [thruster](https://github.com/basecamp/thruster) in front of Puma, following the fleet's Rails 8 template app (fl-pos-admin), so the app itself serves digested assets with HTTP caching/compression — the prerequisite for removing the nginx sidecar.

## What changed

- **Gemfile / Gemfile.lock**: uncommented the skeleton `gem "thruster", require: false` line. Lockfile diff is thruster-only: `thruster (0.1.23)` + `thruster (0.1.23-x86_64-linux)` added to GEM, DEPENDENCIES, and CHECKSUMS; no other churn. The lockfile keeps this repo's narrow platform set (`ruby`, `x86_64-linux-musl`); the `x86_64-linux` thrust binary is a static Go executable, so it runs fine on the Alpine (musl) image — same arrangement fl-pos-admin ships.
- **bin/thrust** (new, executable): byte-identical to fl-pos-admin's binstub.
- **Dockerfile**: `CMD ["./bin/thrust", "./bin/rails", "server"]` (fl-pos-admin pattern, replacing `bundle exec puma -C config/puma.rb`), plus `EXPOSE 80` — thruster on its default port 80, Puma on its default 3000. See port findings below.
- **config/environments/production.rb**: removed `config.public_file_server.enabled = false` (it existed only because nginx served `/assets`; Rails 8 defaults static serving on) and set `config.public_file_server.headers = {"cache-control" => "public, max-age=#{1.year.to_i}"}` per fl-pos-admin. No other settings touched.

## Port findings (input for the cru-terraform change — ECS wiring not guessed, only recorded)

- Thruster listens on `HTTP_PORT` (**default 80**) and runs the wrapped server with `PORT` set to `TARGET_PORT` (**default 3000**).
- The canary's current Dockerfile has **no `EXPOSE` line at all**; Puma binds `ENV.fetch("PORT", 3000)` → **3000** (nothing in this repo sets `PORT`).
- This repo contains **no nginx config** — the sidecar's listen port and its proxy target live entirely in cru-terraform. The Dockerfile only declares the shared volumes (`/home/webapp/app/public`, `/home/webapp/app/nginx-conf`).
- fl-pos-admin (sidecar already removed there) uses thruster's default port with `EXPOSE 80` and has its VOLUME lines commented out.
- **Decision (RESOLVED after inspecting cru-terraform + the ECS module): fl-pos-admin pattern — thruster on default :80, Puma on default :3000, `EXPOSE 80`.** The ECS module (`cru-terraform-modules//aws/ecs/app`) uses bridge networking with docker links and `UPSTREAM_APP_PORT=3000`, so:
  - **Intermediate state** (this image deployed, nginx sidecar still present): nginx proxies straight to Puma on :3000 exactly as today; thruster sits idle on :80 in its own container namespace (bridge mode — no collision with the sidecar's :80).
  - **Final state** (after the cru-terraform change, branch `canary-remove-nginx-thruster`): the module sets `nginx = {enabled: false}` + `container_port = 80`, pointing the ALB at this container on :80 → thruster → Puma :3000, health check `/monitors/lb` on traffic-port.
  - Non-root :80 binding is proven in-fleet: fl-pos-admin runs `USER webapp` + `EXPOSE 80` + thruster through this same module in production (Docker sets `ip_unprivileged_port_start=0` in containers).
  - An earlier revision of this PR used `HTTP_PORT=3000`/`TARGET_PORT=3001`; superseded by commit 6331672 for fleet consistency — that scheme would also have broken against the terraform change, which targets container port 80.

## Local verification

CI has not run on this PR yet — the fleet gotcha: checks on a stacked PR only run once it's retargeted to the default branch (or the base merges) and the branch is pushed again; results below are from a local run of the same commands CI uses.

- `bin/rails test`: 1 runs, 1 assertions, **0 failures, 0 errors, 0 skips**
- `bundle exec standardrb --format simple`: 40 files inspected, **no offenses detected**
- `bundle exec brakeman -A -q --no-pager -w2`: **0 errors, 0 security warnings**
- `RAILS_ENV=production bundle exec rake assets:precompile`: succeeds, digested assets written to `public/assets`
- Booted the production app **through thruster** (`HTTP_PORT=8080 TARGET_PORT=3000 RAILS_ENV=production ./bin/thrust ./bin/rails server`, committed `.env`) and curled through the thruster port:
  - `GET /monitors/lb` (health route) → **200** text/plain
  - `GET /` (root) → **200** text/html
  - `GET /assets/application-2300cf8e.css` (digested asset) → **200 served by the app** with `Cache-Control: public, max-age=31556952` and `X-Cache: miss`, then `X-Cache: hit` on the second request — thruster's cache layer confirmed in the path
  - server stopped cleanly afterward

Local-only note: macOS dev machines resolve thruster's generic gem under this repo's narrow-platform lockfile (thruster ships no darwin binary in the generic gem), so the boot test used the same-version `thruster 0.1.23` arm64-darwin platform gem installed globally. The Docker image is unaffected — bundler installs `thruster 0.1.23-x86_64-linux` per the lockfile.

## DEPLOY SEQUENCING (important)

1. This PR merges **after** the propshaft PR (#141) — it is stacked on it.
2. The canary must **deploy with thruster serving assets** (verify `/assets/*` responses come from the app, e.g. via the `X-Cache` header) **before** the nginx sidecar removal merges in cru-terraform. Do **not** merge the sidecar removal until that deploy is confirmed — during the transition, nginx keeps fronting the container and proxies into thruster on :3000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

