### PR TITLE
test: pin ruby-vips 2.1.4 as a boot-guard fixture (ADL-23)

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,6 +17,14 @@ jobs:
       - name: Check out files
         uses: actions/checkout@v6
 
+      # ubuntu-latest ships no libvips, but the fleet's Docker images carry
+      # 8.15-8.17. Rails 8.0.5.1+ checks BOTH libvips >= 8.13 and ruby-vips
+      # >= 2.2.1 at boot (CVE-2026-66066), so without this the guard would trip
+      # on the missing system library and mask the gem version it is really
+      # testing — see the ruby-vips fixture pin in the Gemfile (ADL-23).
+      - name: Install libvips
+        run: sudo apt-get update && sudo apt-get install -y libvips
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,12 @@ gem "thruster", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+# Boot-guard fixture, pinned below the floor on purpose (ADL-23). Rails 8.0.5.1
+# and later refuse to boot when ruby-vips < 2.2.1 is bundled (CVE-2026-66066),
+# so this pin gives the Renovate preset's ruby-vips carve-out something to find
+# and makes the canary representative of the fleet apps that carry the gem.
+gem "ruby-vips", "= 2.1.4"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri windows], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,6 +283,8 @@ GEM
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.38.0, < 2.0)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.1.4)
+      ffi (~> 1.12)
     securerandom (0.4.1)
     sidekiq (7.3.9)
       base64
@@ -357,6 +359,7 @@ DEPENDENCIES
   rails (~> 8.0.5)
   rake
   redis-actionpack
+  ruby-vips (= 2.1.4)
   sidekiq (~> 7.3)
   sidekiq-pro!
   sqlite3 (>= 2.1)
@@ -469,6 +472,7 @@ CHECKSUMS
   rubocop-ast (1.48.0) sha256=22df9bbf3f7a6eccde0fad54e68547ae1e2a704bf8719e7c83813a99c05d2e76
   rubocop-performance (1.25.0) sha256=6f7d03568a770054117a78d0a8e191cefeffb703b382871ca7743831b1a52ec1
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  ruby-vips (2.1.4) sha256=ef3c08c11c18141ff1efc09f780b96da9c357cb2f98832f1d029670348bfffa6
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   sidekiq (7.3.9) sha256=1108712e1def89002b28e3545d5ae15d4a57ffd4d2c25d97bb1360988826b5a7
   sidekiq-pro (7.3.6) sha256=502aae85b41a7dd3de973b7a05a560437628b70aeb59784370cd65a761945cfa


### PR DESCRIPTION
Sets up the canary to prove the Renovate preset's new ruby-vips carve-out actually works ([CruGlobal/renovate#4](https://github.com/CruGlobal/renovate/pull/4), [ADL-23](https://flightdeck.cru.org/cru/projects/124/items/36636)).

## Why

Rails 8.0.5.1 / 8.1.3.1 / 7.2.3.1 — the CVE-2026-66066 patches — refuse to boot when `ruby-vips` < 2.2.1 is in the bundle. Bumping only Rails onto ruby-vips 2.1.4 took mpdx_api down on all six test shards on 2026-07-29.

Renovate cannot pair the two updates in one PR (vulnerability-driven updates force `groupName: null`, so security PRs are always individual), so the preset instead keeps ruby-vips proactively current — a narrow bundler-only carve-out re-enabling routine patch+minor updates, labeled `boot-guard-prereq`. That mechanism is source-verified and passes `renovate-config-validator`, but it has never run live. The canary had no `ruby-vips` at all (`image_processing` is commented out), so there was nothing for it to find.

## What this does

- Pins `ruby-vips` at `= 2.1.4`, deliberately below the floor. The canary is this program's test bed, so the fixture is intentional and permanent — the same pattern as the existing pinned `puma` fixture.
- Installs libvips in the `test` job. `ubuntu-latest` ships none, while the fleet's Docker images carry 8.15–8.17. The boot guard checks *both* the system library (>= 8.13) and the gem (>= 2.2.1), so without this CI would trip on the missing library and mask the gem version actually under test.

## What to expect

The pin is inert today: the canary is on Rails 8.0.5, which predates the guard, and nothing loads the gem. CI here should be green.

It stops being inert when the pending **critical `activestorage` 8.0.5 → 8.0.5.1** alert gets picked up. That is a patch-level update, and this repo auto-merges patch updates unattended — so it becomes a live test of whether CI catches the guard and blocks the auto-merge. The canary's `test_helper.rb` requires `config/environment`, so the suite does boot the app and should catch it. That distinction matters for the fleet: if real suites catch it, the danger concentrates in repos with vacuous CI.

Two things to watch after this merges:
1. Renovate proposes `ruby-vips` 2.1.4 → 2.3.0 (minor, review-tier, `boot-guard-prereq`) — that is the carve-out working.
2. Whatever happens with the activestorage patch, which is the boot-guard scenario itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQKobp5hqgnvA8PWnCVfTU