### PR TITLE
ci: adopt security-only Dependabot for gems (patch-grouped, contribsys)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,43 @@
 version: 2
+registries:
+  contribsys:
+    type: rubygems-server
+    url: 'https://gems.contribsys.com/'
+    # Org-level Dependabot secret (cru-terraform github/CruGlobal/secrets/
+    # rails_variables.tf), auto-scoped to all CruGlobal Ruby repos; the
+    # SSM-backed value is the user:password pair Basic auth needs.
+    token: ${{secrets.BUNDLE_GEMS__CONTRIBSYS__COM}}
 updates:
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  commit-message:
+    prefix: "ci(deps)"
+# Gems are security-only: open-pull-requests-limit: 0 suppresses routine
+# version-bump PRs while security PRs (exempt from the limit) still open.
+# Patch-level security fixes Dependabot can apply group into a single PR
+# eligible for the strict auto-merge tier; minor/major security fixes
+# fall outside the group and arrive individually for human review.
+# Fixes Dependabot cannot apply (parent constraint would be exceeded)
+# surface as "cannot update" alerts, not PRs — the nightly digest reads
+# those. Do not set target-branch here: security updates only follow
+# this entry's settings when none is set.
+- package-ecosystem: bundler
+  directory: "/"
+  insecure-external-code-execution: allow
+  registries:
+  - contribsys
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 0
+  commit-message:
+    prefix: "fix(deps)"
+  groups:
+    security-patches:
+      applies-to: security-updates
+      update-types:
+      - "patch"
+      patterns:
+      - "*"


### PR DESCRIPTION
## What

Adds the `bundler` ecosystem to dependabot.yml in **security-only** mode, per the ratified engine decision (CruGlobal/renovate spec, decision 21):

- `open-pull-requests-limit: 0` — no routine version-bump PRs; security PRs are exempt from the limit and still get this entry's customizations (registries, groups, commit prefix).
- `security-patches` group (`applies-to: security-updates`, `update-types: ["patch"]`) — patch-level fixes group into one auto-merge-eligible PR; minor/major security fixes arrive individually for human review.
- Contribsys registry via the **org-level** `BUNDLE_GEMS__CONTRIBSYS__COM` Dependabot secret (SSM-backed, auto-scoped to all CruGlobal Ruby repos) — no per-repo secret needed.
- Conventional-commit prefixes (`fix(deps)` / `ci(deps)`) so PR titles pass fleet title linting.

## Ordering

**Merge this before applying the cru-terraform PR** that re-enables `dependabot_security_updates` on this repo, so the registry config exists when security jobs first run.

## Expected first-night results (validate against these)

1. ONE grouped PR `fix(deps): bump the security-patches group with N updates` — the patch-level fixes Dependabot can apply lockfile-only (concurrent-ruby etc.). CI expected GREEN.
2. ONE individual PR for datadog (direct, minor [SECURITY]) — outside the patch group; must NOT be auto-merge-eligible.
3. **NO PR for activestorage 8.0.5 → 8.0.5.1**: rails 8.0.5 pins it exactly, and Dependabot won't bump a transitive gem when the parent must move. Expect a "Dependabot cannot update…" annotation on the alert instead — this is the parent-constraint-blocked class the nightly digest will surface as needs-Gemfile-bump items (ADL-33). The ruby-vips boot-guard fail-closed demo therefore needs a manual `bundle update --conservative rails` PR, not a Dependabot one.
4. No PR touches ruby-vips (pinned 2.1.4 fixture, no advisory).

Tracking: FlightDeck ADL-30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yzCDohfe5D273aS6DXYYc